### PR TITLE
Add stripping of UTF-8 BOM on input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add changelog
+- Add stripping of UTF-8 BOM on input files
 
 ### Security
 

--- a/bin/arm-template-merge
+++ b/bin/arm-template-merge
@@ -26,6 +26,8 @@ const mergeARMTemplates = require('../');
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 
+const utf8BOM = Buffer.from([0xEF, 0xBB, 0xBF]);
+
 /* eslint no-console: off */
 
 cli(process.argv.slice(2));
@@ -126,7 +128,14 @@ async function mergeTemplateWith(target, inFile) {
 }
 
 async function loadTemplate(inFile) {
-  let json = await readFile(inFile, 'utf8');
+  let jsonBuf = await readFile(inFile);
+
+  // Strip the UTF-8 BOM, if present
+  if (jsonBuf.slice(0, 3).equals(utf8BOM)) {
+    jsonBuf = jsonBuf.slice(3);
+  }
+
+  let json = jsonBuf.toString('utf8');
   let template = JSON.parse(json);
 
   for (let key of ['$schema', 'contentVersion']) {


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

Resolves #4 
